### PR TITLE
Store.createObjects

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": "airbnb",
   "rules": {
+    "no-shadow": "off",
     "object-curly-spacing": ["error", "never"],
     "consistent-return": "off",
     "no-param-reassign": "off",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dispersive",
-  "version": "0.16.8",
+  "version": "0.16.9",
   "description": "Storage management inspired by the Flux philosophy",
   "main": "lib",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dispersive",
-  "version": "0.16.9",
+  "version": "0.16.10",
   "description": "Storage management inspired by the Flux philosophy",
   "main": "lib",
   "scripts": {

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -1,8 +1,5 @@
 const FluxDispatcher = require('flux').Dispatcher;
 
-const defer = (handler, ...args) => setTimeout(
-  () => handler(...args)
-, 0);
 
 class Dispatcher extends FluxDispatcher {
 
@@ -28,7 +25,7 @@ class Dispatcher extends FluxDispatcher {
   wakeUp(event) {
     const handlers = this.mapping[event.actionType] || [];
 
-    handlers.forEach(handler => defer(handler, event.data));
+    handlers.forEach(handler => handler(event.data));
   }
 
   trigger(action, event) {

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -1,5 +1,8 @@
 const FluxDispatcher = require('flux').Dispatcher;
 
+const defer = (handler, ...args) => setTimeout(
+  () => handler(...args)
+, 0);
 
 class Dispatcher extends FluxDispatcher {
 
@@ -25,7 +28,7 @@ class Dispatcher extends FluxDispatcher {
   wakeUp(event) {
     const handlers = this.mapping[event.actionType] || [];
 
-    handlers.forEach((handler) => handler(event.data));
+    handlers.forEach(handler => defer(handler, event.data));
   }
 
   trigger(action, event) {

--- a/src/manager.js
+++ b/src/manager.js
@@ -73,7 +73,9 @@ class UniqueIndex extends Index {
   }
 
   link(val, values) {
-    if (val in this.kvs) throw new UniqueIndex.AlreadyExists(this.name, val);
+    if (val in this.kvs && this.kvs[val].id !== values.id) {
+      throw new UniqueIndex.AlreadyExists(this.name, val);
+    }
 
     this.kvs[val] = values;
   }

--- a/src/store.js
+++ b/src/store.js
@@ -5,17 +5,21 @@ const Tree = require('./tree');
 
 class Store extends Tree {
 
-  _register(name, {model = null, schema = {}, manager = ObjectManager}) {
+  static createObjects({model = null, schema = {}, manager = ObjectManager}) {
     const ModelType = model || class extends Model {};
     const ManagerType = ModelType.manager || manager;
 
     ModelType.schema = new Schema(ModelType.schemaFields || schema);
     ModelType.objects = new ManagerType(ModelType);
 
-    this[name] = ModelType.objects;
+    return ModelType.objects;
+  }
+
+  _register(name, {model = null, schema = {}, manager = ObjectManager}) {
+    this[name] = Store.createObjects({model, schema, manager});
     this._leafs.add(name);
 
-    return ModelType;
+    return this[name];
   }
 
   create(data) {

--- a/src/store.js
+++ b/src/store.js
@@ -5,7 +5,7 @@ const Tree = require('./tree');
 
 class Store extends Tree {
 
-  static createObjects({model = null, schema = {}, manager = ObjectManager}) {
+  static _createObjects({model = null, schema = {}, manager = ObjectManager}) {
     const ModelType = model || class extends Model {};
     const ManagerType = ModelType.manager || manager;
 
@@ -15,8 +15,14 @@ class Store extends Tree {
     return ModelType.objects;
   }
 
-  _register(name, {model = null, schema = {}, manager = ObjectManager}) {
-    this[name] = Store.createObjects({model, schema, manager});
+  static createObjects(spec = {}) {
+    return Store._createObjects(spec);
+  }
+
+  _register(name, spec = {}) {
+    const objects = (spec instanceof ObjectManager) ? spec : Store.createObjects(spec);
+
+    this[name] = objects;
     this._leafs.add(name);
 
     return this[name];

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -93,6 +93,23 @@ describe('Action', () => {
     action1();
   });
 
+  it('should trigger before the promise resolution (#38)', done => {
+    const subscriptionSpy = sinon.spy();
+    const resolutionSpy = sinon.spy();
+    const action = createAction(() => new Promise(resolve => setTimeout(resolve, 10)));
+
+    action.subscribe(() => {
+      assert(!resolutionSpy.called);
+      subscriptionSpy()
+    });
+
+    action().then(() => {
+      resolutionSpy();
+      assert(subscriptionSpy.called);
+      done();
+    });
+  });
+
   describe('Tree', () => {
 
     it('should add action from handler', done => {

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -343,6 +343,20 @@ describe('Store', () => {
     });
 
 
+    it('should be able to update an element with unique field (#37)', () => {
+      const schema = {
+        value: false,
+        name: {index: true, unique: true},
+      };
+
+      const testStore = Dispersive.Store.createObjects({schema});
+
+      testStore.create({name: "foo"});
+      testStore.get({name: "foo"}).update({value: true});
+
+      assert.throws(() => testStore.create({name: "foo"}));
+    });
+
   });
 
 

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -321,13 +321,12 @@ describe('Store', () => {
     });
 
     it('should be able to use empty arrays as initial values (#21)', () => {
-      const store = new Dispersive.Store();
-      const Pokemon = store.register('pokemons', {schema: {name: null, words: []}});
-      const nobody = Pokemon.objects.create({name: 'nobody'});
+      const pokemons = Dispersive.Store.createObjects({schema: {name: null, words: []}});
+      const nobody = pokemons.create({name: 'nobody'});
 
       assert.deepEqual([], nobody.words);
 
-      const pikachu = Pokemon.objects.create({name: 'pikachu', words: ['pikapika', 'pikachu']});
+      const pikachu = pokemons.create({name: 'pikachu', words: ['pikapika', 'pikachu']});
 
       assert.deepEqual(['pikapika', 'pikachu'], pikachu.words);
     });

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -37,6 +37,17 @@ describe('Store', () => {
     assert.deepEqual(rootStore.tree, ['market.products']);
   });
 
+  it('should register pre-created sub store', () => {
+    const rootStore = new Dispersive.Store();
+    const market = new Dispersive.Store();
+    const products = Dispersive.Store.createObjects();
+
+    market.register({products});
+
+    rootStore.register('market', market);
+    assert.deepEqual(rootStore.tree, ['market.products']);
+  });
+
   it('should create models from data tree', () => {
     const rootStore = new Dispersive.Store();
     const market = new Dispersive.Store();


### PR DESCRIPTION
Now it's possible to create store objects before registering them

```js
const schema = {name: null, price: 0};
const products = Store.createObjects({schema});

store.register({products});

// with parent
store.products.create({name: 'something'});

// with objects directlly
products.first().name // something
```